### PR TITLE
Window bottom cut off when using default gap sizes

### DIFF
--- a/dynamic-floating-group.lisp
+++ b/dynamic-floating-group.lisp
@@ -342,7 +342,8 @@ the parameter MASTER-RATIO and CURRENT-LAYOUT."
 
       (setf sw (- sw (* 2 stumpwm::*float-window-border*)))
       (setf sh (- sh (* 2 stumpwm::*float-window-border*)
-                  (head-mode-line-height)))
+                  (head-mode-line-height)
+                  stumpwm::*float-window-title-height*))
 
       (case N
         (0 nil)


### PR DESCRIPTION
It might be a bit hard to see in the image, but with the default configuration there's a few pixels missing on the bottom of windows, at least with the resolution I currently use, `3440x1440`.

![gap-cut](https://user-images.githubusercontent.com/626791/133603783-fe7feb93-062c-4a40-90e4-c945e4357e56.png)

I figure there's a really simple fix -- haven't had a look myself yet.

...and thanks for DFG. Just started using it, and it seems like a really good start.